### PR TITLE
build: add TRACY_SUPPORT cmake option and fix vcpkg baseline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: write
 
-env:
-  VCPKG_COMMIT_ID: 34742e119fb2aae42f10c03a98e475eb1934f7c9
-
 jobs:
   compile:
     name: build plugin and addons
@@ -23,9 +20,9 @@ jobs:
 
         - uses: ilammy/msvc-dev-cmd@v1.10.0
 
-        - uses: lukka/run-vcpkg@v11
+        - uses: lukka/run-vcpkg@v11.5
           with:
-              vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
+            vcpkgJsonGlob: vcpkg.json
 
         - name: cmake configure
           run: cmake -S . --preset=ALL --check-stamp-file "build\CMakeFiles\generate.stamp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,11 @@ message("Options:")
 option(AUTO_PLUGIN_DEPLOYMENT "Copy the build output and addons to env:CommunityShadersOutputDir." OFF)
 option(ZIP_TO_DIST "Zip the base mod and addons to their own 7z file in dist." ON)
 option(AIO_ZIP_TO_DIST "Zip the base mod and addons to a AIO 7z file in dist." ON)
-option(TRACY_ENABLE "Enable support for tracy profiler" ON)
+option(TRACY_SUPPORT "Enable support for tracy profiler" OFF)
 message("\tAuto plugin deployment: ${AUTO_PLUGIN_DEPLOYMENT}")
 message("\tZip to dist: ${ZIP_TO_DIST}")
 message("\tAIO Zip to dist: ${AIO_ZIP_TO_DIST}")
-message("\tTracy profiler: ${TRACY_ENABLE}")
+message("\tTracy profiler: ${TRACY_SUPPORT}")
 
 # #######################################################################################################################
 # # Add CMake features
@@ -47,6 +47,12 @@ find_package(Tracy CONFIG REQUIRED)
 set(NVAPI_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/extern/nvapi/" CACHE STRING "Path to NVAPI include headers/shaders" )
 set(NVAPI_LIBRARY "${CMAKE_SOURCE_DIR}/extern/nvapi/amd64/nvapi64.lib" CACHE STRING "Path to NVAPI .lib file")
 
+target_compile_definitions(
+	${PROJECT_NAME}
+	PRIVATE
+	"$<$<BOOL:${TRACY_SUPPORT}>:TRACY_SUPPORT>"
+)
+
 target_include_directories(
 	${PROJECT_NAME}
 	PRIVATE
@@ -72,7 +78,7 @@ target_link_libraries(
 	unordered_dense::unordered_dense
 	efsw::efsw
 	Tracy::TracyClient
-	 ${NVAPI_LIBRARY} 
+	${NVAPI_LIBRARY} 
 )
 
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,7 +58,8 @@
 				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "ON",
 				"ENABLE_SKYRIM_SE": "OFF",
-				"ENABLE_SKYRIM_VR": "OFF"
+				"ENABLE_SKYRIM_VR": "OFF",
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",
@@ -73,7 +74,8 @@
 				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "OFF",
 				"ENABLE_SKYRIM_SE": "ON",
-				"ENABLE_SKYRIM_VR": "OFF"
+				"ENABLE_SKYRIM_VR": "OFF",
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",
@@ -88,7 +90,8 @@
 				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "OFF",
 				"ENABLE_SKYRIM_SE": "OFF",
-				"ENABLE_SKYRIM_VR": "ON"
+				"ENABLE_SKYRIM_VR": "ON",
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",
@@ -103,7 +106,8 @@
 				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "ON",
 				"ENABLE_SKYRIM_SE": "ON",
-				"ENABLE_SKYRIM_VR": "ON"
+				"ENABLE_SKYRIM_VR": "ON",
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",
@@ -118,7 +122,8 @@
 				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "OFF",
 				"ENABLE_SKYRIM_SE": "ON",
-				"ENABLE_SKYRIM_VR": "ON"
+				"ENABLE_SKYRIM_VR": "ON",
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",
@@ -134,7 +139,7 @@
 				"ENABLE_SKYRIM_AE": "ON",
 				"ENABLE_SKYRIM_SE": "ON",
 				"ENABLE_SKYRIM_VR": "OFF",
-				"Build Tests": "OFF"
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",

--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@ If you want an example CMakeUserPreset to start off with you can copy the `CMake
 * Make sure `"AUTO_PLUGIN_DEPLOYMENT"` is set to `"ON"` in `CMakeUserPresets.json`
 * Change the `"CommunityShadersOutputDir"` value to match your desired outputs, if you want multiple folders you can separate them by `;` is shown in the template example
 #### AIO_ZIP_TO_DIST
-* This option is default `"OFF"`
+* This option is default `"ON"`
 * Make sure `"AIO_ZIP_TO_DIST"` is set to `"ON"` in `CMakeUserPresets.json`
 * This will create a `CommunityShaders_AIO.7z` archive in /dist containing all features and base mod
 #### ZIP_TO_DIST
 * This option is default `"ON"`
 * Make sure `"ZIP_TO_DIST"` is set to `"ON"` in `CMakeUserPresets.json`
 * This will create a zip for each feature and one for the base Community shaders in /dist containing
+#### TRACY_SUPPORT
+* This option is default `"OFF"`
+* This will enable tracy support, might need to delete build folder when this option is changed
+
 
 When using custom preset you can call BuildRelease.bat with an parameter to specify which preset to configure eg:
 `.\BuildRelease.bat ALL-WITH-AUTO-DEPLOYMENT`

--- a/include/PCH.h
+++ b/include/PCH.h
@@ -31,6 +31,10 @@ void* operator new[](size_t size, size_t alignment, size_t alignmentOffset, cons
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+#ifndef TRACY_SUPPORT
+	#undef TRACY_ENABLE
+#endif
+
 using namespace std::literals;
 
 namespace stl

--- a/src/State.h
+++ b/src/State.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Tracy/Tracy.hpp>
 #include <Tracy/TracyD3D11.hpp>
 
 #include <Buffer.h>
@@ -144,8 +145,10 @@ public:
 
 	inline ~State()
 	{
+#ifdef TRACY_ENABLE
 		if (tracyCtx)
 			TracyD3D11Destroy(tracyCtx);
+#endif
 	}
 
 private:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,41 +1,46 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "communityshaders",
-  "version-semver": "0.7.4",
-  "description": "",
   "license": "GPL-3.0",
+  "features": {
+    "commonlibsse-ng": {
+      "description": "Dependencies of clib-ng",
+      "dependencies": ["fmt", "directxtk", "rapidcsv", "spdlog"]
+    }
+  },
+  "default-features": ["commonlibsse-ng"],
   "dependencies": [
     "bshoshany-thread-pool",
+    "clib-util",
     "cppwinrt",
-    "fmt",
-    "directxtk",
-    "rapidcsv",
-    "spdlog",
+    "directxtex",
+    "eastl",
+    "efsw",
+    {
+      "name": "imgui",
+      "features": ["dx11-binding", "win32-binding", "docking-experimental"]
+    },
     "magic-enum",
-    "xbyak",
-    "catch2",
     "magic-enum",
     "nlohmann-json",
     "pystring",
-    "directxtex",
-    {
-      "name": "imgui",
-      "features": ["dx11-binding", "win32-binding", "docking-experimental"],
-      "version>=": "1.88"
-    },
-    "eastl",
-    "clib-util",
+    "tracy",
     "unordered-dense",
-    "efsw",
-    {
-      "name": "tracy",
-      "version>=": "0.11.0"
-    }
+    "xbyak"
   ],
   "overrides": [
     {
       "name": "bshoshany-thread-pool",
-      "version-string": "3.5.0"
+      "version": "3.5.0"
+    },
+    {
+      "name": "imgui",
+      "version": "1.90"
+    },
+    {
+      "name": "tracy",
+      "version": "0.11.0"
     }
   ],
-  "builtin-baseline": "83972272512ce4ede5fc3b2ba98f6468b179f192"
+  "builtin-baseline": "1dc5ee30eb1032221d29f281f4a94b73f06b4284"
 }


### PR DESCRIPTION
Had to rename the cmake option to `TRACY_SUPPORT` due to `TRACY_ENABLE` being hardcoded to defined when using cmake target. Added a undef to that if `TRACY_SUPPORT` is set to `OFF` (which is now default)