### PR TITLE
fix: disable in loading menu (and save clouds)

### DIFF
--- a/src/Features/PhysicalSky.cpp
+++ b/src/Features/PhysicalSky.cpp
@@ -33,7 +33,11 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	aerosolAbsorption,
 	ozoneAltitude,
 	ozoneThickness,
-	ozoneAbsorption)
+	ozoneAbsorption,
+	cloudRelightMix,
+	cloudOriginalMix,
+	silverLiningMix,
+	silverLiningSpread)
 
 namespace
 {
@@ -461,6 +465,8 @@ void PhysicalSky::Reset()
 	// check worldspace
 	bool worldspaceEnabled = false;
 	bool inInterior = false;
+	bool inMainLoadingMenu = globals::game::ui && (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+
 	WorldspaceInfo worldspaceInfo = {};
 	if (globals::game::tes) {
 		if (auto worldspace = globals::game::tes->GetRuntimeData2().worldSpace; worldspace) {
@@ -475,7 +481,7 @@ void PhysicalSky::Reset()
 			}
 		}
 	}
-	allGood &= worldspaceEnabled && !inInterior;
+	allGood &= worldspaceEnabled && !inInterior && !inMainLoadingMenu;
 
 	if (!allGood) {
 		cbData.enabled = allGood;


### PR DESCRIPTION
This pull request updates the `PhysicalSky` feature to improve configuration handling and ensure it is disabled in main and loading menus. The most important changes are grouped below:

**Configuration Serialization Enhancements:**

* Added new parameters (`cloudRelightMix`, `cloudOriginalMix`, `silverLiningMix`, `silverLiningSpread`) to the `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT` macro for JSON serialization/deserialization, allowing these cloud and lighting properties to be saved and loaded.

**Logic and State Handling Improvements:**

* Added a check for whether the main menu or loading menu is open (`inMainLoadingMenu`) in the `PhysicalSky::Reset()` method, ensuring the feature is aware of the UI state.
* Updated the logic that determines whether the `PhysicalSky` feature is enabled to also require that the main and loading menus are not open, preventing the feature from being active during those times.