### PR TITLE
fix: restore sampler after sky pass

### DIFF
--- a/src/Features/PhysicalSky.cpp
+++ b/src/Features/PhysicalSky.cpp
@@ -688,15 +688,33 @@ void PhysicalSky::AccumShadow()
 
 void PhysicalSky::ModifySky()
 {
+	auto context = globals::d3d::context;
+	context->PSGetSamplers(3, 2, originalPSSamplers);
+
 	auto samplers = std::array{ sampTr.get(), sampSv.get() };
-	globals::d3d::context->PSSetSamplers(3, static_cast<UINT>(samplers.size()), samplers.data());
+	context->PSSetSamplers(3, static_cast<UINT>(samplers.size()), samplers.data());
 
 	GET_INSTANCE_MEMBER(PSSamplerModifiedBits, globals::game::shadowState);
 	PSSamplerModifiedBits |= (1 << 3);
 }
 
-void PhysicalSky::Hooks::BSSkyShader_SetupMaterial::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+void PhysicalSky::RestoreSamplers()
+{
+	auto context = globals::d3d::context;
+	context->PSSetSamplers(3, 2, originalPSSamplers);
+
+	GET_INSTANCE_MEMBER(PSSamplerModifiedBits, globals::game::shadowState);
+	PSSamplerModifiedBits &= ~(1 << 3);
+}
+
+void PhysicalSky::Hooks::BSSkyShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
 	globals::features::physicalSky.ModifySky();
+	func(This, Pass, RenderFlags);
+}
+
+void PhysicalSky::Hooks::BSSkyShader_RestoreGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+{
+	globals::features::physicalSky.RestoreSamplers();
 	func(This, Pass, RenderFlags);
 }

--- a/src/Features/PhysicalSky.h
+++ b/src/Features/PhysicalSky.h
@@ -195,10 +195,19 @@ struct PhysicalSky final : public Feature
 	winrt::com_ptr<ID3D11ComputeShader> csApLutGen = nullptr;
 	winrt::com_ptr<ID3D11ComputeShader> csShadowAccum = nullptr;
 
+	ID3D11SamplerState* originalPSSamplers[2] = { nullptr, nullptr };
+
 	void ModifySky();
+	void RestoreSamplers();
 	struct Hooks
 	{
-		struct BSSkyShader_SetupMaterial
+		struct BSSkyShader_SetupGeometry
+		{
+			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
+			static inline REL::Relocation<decltype(thunk)> func;
+		};
+
+		struct BSSkyShader_RestoreGeometry
 		{
 			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
@@ -206,7 +215,8 @@ struct PhysicalSky final : public Feature
 
 		static void Install()
 		{
-			stl::write_vfunc<0x6, BSSkyShader_SetupMaterial>(RE::VTABLE_BSSkyShader[0]);
+			stl::write_vfunc<0x6, BSSkyShader_SetupGeometry>(RE::VTABLE_BSSkyShader[0]);
+			stl::write_vfunc<0x7, BSSkyShader_RestoreGeometry>(RE::VTABLE_BSSkyShader[0]);
 		}
 	};
 };


### PR DESCRIPTION
This pull request refactors how sampler state changes are managed in the `PhysicalSky` feature. The main improvement is the introduction of a mechanism to restore the original pixel shader samplers after modification, ensuring proper state management and preventing potential rendering issues. The hooks for modifying and restoring the samplers have been restructured for clarity and correctness.

**Sampler State Management Improvements:**

* Added an `originalPSSamplers` array to `PhysicalSky` to store the original pixel shader samplers, and implemented the `RestoreSamplers()` method to restore them after modifications.
* Updated `ModifySky()` to save the current samplers before setting new ones, and added logic in `RestoreSamplers()` to revert to the original state and update the `PSSamplerModifiedBits` accordingly.

**Hook Restructuring:**

* Replaced the old `BSSkyShader_SetupMaterial` hook with two new hooks: `BSSkyShader_SetupGeometry` (for applying sampler modifications) and `BSSkyShader_RestoreGeometry` (for restoring the original samplers), and updated the virtual function table installation accordingly. [[1]](diffhunk://#diff-6a2b241491fda4de35594f344e80216bc32031e1e845c00144da936b04d70d6cR198-R219) [[2]](diffhunk://#diff-4d56d548df2318d98481c439a7700d91225a539e944f881b78b160c60d2e554eR691-R720)